### PR TITLE
Implement performant WaitQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _Currently under heavy development—APIs and internals will break._
 | **`lib.rs`**       | Crate entry; feature gates & public re-exports.            |
 | **`semaphore.rs`** | Core `PrioritySemaphore` logic (permits, dispatch, close). |
 | **`permit.rs`**    | RAII guard that returns the permit on `Drop`.              |
-| **`queue.rs`**     | `BinaryHeap`-based wait queue (`push / pop / remove`).     |
+| **`queue.rs`**     | High-performance heap queue (`push / pop / remove`).     |
 | **`waiter.rs`**    | `AcquireFuture`; cancellation-safe `poll` & cleanup.       |
 | **`error.rs`**     | Tiny error enums (`TryAcquireError`, `AcquireError`).      |
 | **`util.rs`**      | Misc helpers/macros (`doc_cfg`, loom shims, etc.).         |

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,6 +1,6 @@
 //! Priority-ordered wait-queue based on `BinaryHeap`.
 
-use alloc::collections::BinaryHeap;
+use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::task::Waker;
 use crate::semaphore::Priority;
@@ -32,31 +32,88 @@ impl PartialOrd for WaiterEntry {
 
 /// Heap-based queue wrapper.
 pub(crate) struct WaitQueue {
-    heap: BinaryHeap<WaiterEntry>,
+    heap: Vec<WaiterEntry>,
     next_id: usize,
 }
 
 impl WaitQueue {
     pub const fn new() -> Self {
         Self {
-            heap: BinaryHeap::new(),
+            heap: Vec::new(),
             next_id: 0,
         }
     }
 
     pub fn push(&mut self, prio: Priority, weight: u32, waker: Waker) -> usize {
-        unimplemented!()
+        let id = self.next_id;
+        self.next_id += 1;
+        self.heap.push(WaiterEntry { prio, waker, id, weight });
+        self.sift_up(self.heap.len() - 1);
+        id
     }
 
     pub fn pop(&mut self) -> Option<WaiterEntry> {
-        unimplemented!()
+        if self.heap.is_empty() {
+            return None;
+        }
+        let last = self.heap.pop().unwrap();
+        if self.heap.is_empty() {
+            return Some(last);
+        }
+        let ret = core::mem::replace(&mut self.heap[0], last);
+        self.sift_down(0);
+        Some(ret)
     }
 
     pub fn remove(&mut self, id: usize) {
-        unimplemented!()
+        if let Some(pos) = self.heap.iter().position(|e| e.id == id) {
+            let last = self.heap.pop().unwrap();
+            if pos == self.heap.len() {
+                return;
+            }
+            self.heap[pos] = last;
+            if pos > 0 && self.heap[pos] > self.heap[(pos - 1) / 2] {
+                self.sift_up(pos);
+            } else {
+                self.sift_down(pos);
+            }
+        }
     }
 
     pub fn len(&self) -> usize {
         self.heap.len()
+    }
+
+    #[inline]
+    fn sift_up(&mut self, mut idx: usize) {
+        while idx > 0 {
+            let parent = (idx - 1) >> 1;
+            if self.heap[parent] >= self.heap[idx] {
+                break;
+            }
+            self.heap.swap(parent, idx);
+            idx = parent;
+        }
+    }
+
+    #[inline]
+    fn sift_down(&mut self, mut idx: usize) {
+        let len = self.heap.len();
+        loop {
+            let left = (idx << 1) + 1;
+            if left >= len {
+                break;
+            }
+            let right = left + 1;
+            let mut child = left;
+            if right < len && self.heap[right] > self.heap[left] {
+                child = right;
+            }
+            if self.heap[idx] >= self.heap[child] {
+                break;
+            }
+            self.heap.swap(idx, child);
+            idx = child;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement WaitQueue using a custom heap for efficient push/pop/remove
- update README to describe the improved queue implementation

## Testing
- `cargo check`
- `cargo test --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685a4c3576a4832c94354a2d4da79a25