### PR TITLE
Optimize semaphore implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod permit;
 mod queue;
 mod semaphore;
+mod lock;
 mod util;
 mod waiter;
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,29 @@
+#[cfg(feature = "std")]
+pub(crate) mod imp {
+    use std::sync::{Mutex as StdMutex, MutexGuard as StdGuard};
+
+    pub(crate) struct Lock<T>(StdMutex<T>);
+
+    impl<T> Lock<T> {
+        pub const fn new(value: T) -> Self { Self(StdMutex::new(value)) }
+        pub fn lock(&self) -> StdGuard<'_, T> { self.0.lock().unwrap() }
+    }
+
+    pub(crate) type LockGuard<'a, T> = StdGuard<'a, T>;
+}
+
+#[cfg(not(feature = "std"))]
+pub(crate) mod imp {
+    use core::cell::{RefCell, RefMut};
+
+    pub(crate) struct Lock<T>(RefCell<T>);
+
+    impl<T> Lock<T> {
+        pub const fn new(value: T) -> Self { Self(RefCell::new(value)) }
+        pub fn lock(&self) -> RefMut<'_, T> { self.0.borrow_mut() }
+    }
+
+    pub(crate) type LockGuard<'a, T> = RefMut<'a, T>;
+}
+
+pub(crate) use imp::{Lock, LockGuard};

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -80,6 +80,12 @@ impl WaitQueue {
         }
     }
 
+    pub fn update_waker(&mut self, id: usize, waker: Waker) {
+        if let Some(entry) = self.heap.iter_mut().find(|e| e.id == id) {
+            entry.waker = waker;
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.heap.len()
     }


### PR DESCRIPTION
## Summary
- implement fully functional priority semaphore
- add simple cross-platform lock abstraction
- update wait queue with waker update method
- flesh out AcquireFuture behavior

## Testing
- `cargo test --quiet --features std`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685a4daf0e44832cadab2467548bb2cd