### PR TITLE
Improve docs and remove warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,9 +9,32 @@ pub enum TryAcquireError {
     Closed,
 }
 
+impl core::fmt::Display for TryAcquireError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TryAcquireError::NoPermits => write!(f, "no permits available"),
+            TryAcquireError::Closed => write!(f, "semaphore closed"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TryAcquireError {}
+
 /// Returned by async `acquire`.
 #[derive(Debug)]
 pub enum AcquireError {
     /// Semaphore was closed before acquisition succeeded.
     Closed,
 }
+
+impl core::fmt::Display for AcquireError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AcquireError::Closed => write!(f, "semaphore closed"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AcquireError {}

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,37 +1,45 @@
+//! Simple synchronization primitive used internally by the semaphore.
+
 #[cfg(feature = "std")]
 pub(crate) mod imp {
     use std::sync::{Mutex as StdMutex, MutexGuard as StdGuard};
 
+    /// Wrapper around `std::sync::Mutex`.
+    #[derive(Debug)]
     pub(crate) struct Lock<T>(StdMutex<T>);
 
     impl<T> Lock<T> {
+        /// Create a new locked value.
         pub const fn new(value: T) -> Self {
             Self(StdMutex::new(value))
         }
+
+        /// Lock and get mutable access to the inner value.
         pub fn lock(&self) -> StdGuard<'_, T> {
             self.0.lock().unwrap()
         }
     }
-
-    pub(crate) type LockGuard<'a, T> = StdGuard<'a, T>;
 }
 
 #[cfg(not(feature = "std"))]
 pub(crate) mod imp {
     use core::cell::{RefCell, RefMut};
 
+    /// `RefCell` based lock used in `no_std` environments.
+    #[derive(Debug)]
     pub(crate) struct Lock<T>(RefCell<T>);
 
     impl<T> Lock<T> {
+        /// Create a new locked value.
         pub const fn new(value: T) -> Self {
             Self(RefCell::new(value))
         }
+
+        /// Borrow the inner value mutably.
         pub fn lock(&self) -> RefMut<'_, T> {
             self.0.borrow_mut()
         }
     }
-
-    pub(crate) type LockGuard<'a, T> = RefMut<'a, T>;
 }
 
-pub(crate) use imp::{Lock, LockGuard};
+pub(crate) use imp::Lock;

--- a/src/permit.rs
+++ b/src/permit.rs
@@ -4,9 +4,9 @@ use crate::semaphore::PrioritySemaphore;
 use alloc::sync::Arc;
 
 /// Returned by successful acquire; releases permit on `Drop`.
+#[derive(Debug)]
 pub struct Permit {
     root: Arc<PrioritySemaphore>,
-    // you may add weight or id fields here
 }
 
 impl Permit {

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -5,7 +5,9 @@ use crate::{error::*, permit::Permit, queue::WaitQueue, waiter::AcquireFuture};
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-/// 整数が大きいほど高優先度
+/// Priority value used by the semaphore.
+///
+/// Larger numbers represent higher priority.
 pub type Priority = i32;
 
 /// Async-aware priority semaphore.
@@ -14,6 +16,16 @@ pub struct PrioritySemaphore {
     pub(crate) waiters: Lock<WaitQueue>,
     max_permit: usize,
     pub(crate) closed: AtomicBool,
+}
+
+impl core::fmt::Debug for PrioritySemaphore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrioritySemaphore")
+            .field("available", &self.available_permits())
+            .field("queued", &self.queued())
+            .field("closed", &self.closed.load(Ordering::Acquire))
+            .finish()
+    }
 }
 
 impl PrioritySemaphore {

--- a/src/waiter.rs
+++ b/src/waiter.rs
@@ -14,6 +14,7 @@ use core::{
 };
 
 /// Future returned by `PrioritySemaphore::acquire`.
+#[derive(Debug)]
 pub struct AcquireFuture {
     pub(crate) root: Arc<PrioritySemaphore>,
     pub(crate) prio: i32,
@@ -47,7 +48,7 @@ impl Future for AcquireFuture {
 
         if !this.in_queue {
             let mut queue = this.root.waiters.lock();
-            let id = queue.push(this.prio, 1, cx.waker().clone());
+            let id = queue.push(this.prio, cx.waker().clone());
             this.wait_id = Some(id);
             this.in_queue = true;
         } else if let Some(id) = this.wait_id {


### PR DESCRIPTION
## Summary
- add Debug and Display implementations on error types
- document and implement Debug for lock module
- document queue internals and remove unused weight field
- implement Debug for `PrioritySemaphore`
- add small doc updates

## Testing
- `cargo check --all-targets`
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_685a5f5e81b8832cb76814ba85cf5ddd