### PR TITLE
Add examples and multilingual README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,58 @@
+# priority-semaphore 日本語版
+
+Rust 用のランタイム非依存な優先度付き非同期セマフォです。
+
+タスクは署名付きの優先度を指定してパーミットを取得できます。数値が大きい
+ほど高優先度とみなされ、先にウェイクされます。重要な処理を優先しつつ、
+飢餓状態を避けることができます。
+
+## 特徴
+
+- **Tokio** または **async-std** を選択して利用可能
+- キャンセルセーフな `acquire`
+- `ageing` フィーチャによる簡易エージング戦略
+- `unsafe` コードゼロ
+
+## 使用例
+
+```rust
+use std::sync::Arc;
+use priority_semaphore::PrioritySemaphore;
+
+#[tokio::main]
+async fn main() {
+    let sem = Arc::new(PrioritySemaphore::new(1));
+
+    let hi = sem.clone();
+    let h = tokio::spawn(async move {
+        let _permit = hi.acquire(10).await.unwrap();
+        println!("high priority job");
+    });
+
+    let lo = sem.clone();
+    let l = tokio::spawn(async move {
+        let _permit = lo.acquire(1).await.unwrap();
+        println!("low priority job");
+    });
+
+    h.await.unwrap();
+    l.await.unwrap();
+}
+```
+
+詳細な例は [`examples`](./examples) ディレクトリを参照してください。
+
+## クレートのフィーチャ
+
+| フィーチャ | 既定 | 説明                                     |
+|-----------|------|------------------------------------------|
+| `tokio`   | ✔    | Tokio ランタイム用サポート               |
+| `async-std` | ❌ | async-std 用サポート                      |
+| `ageing`  | ❌   | 飢餓状態緩和のための簡易エージング       |
+| `std`     | ✔    | 標準ライブラリを使用                     |
+| `docsrs`  | ❌  | docs.rs ビルド用の内部フィーチャ          |
+
+## ライセンス
+
+このプロジェクトは MIT または Apache License 2.0 のいずれかを
+選択して使用できます。

--- a/examples/priority.rs
+++ b/examples/priority.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+use priority_semaphore::PrioritySemaphore;
+
+#[tokio::main]
+async fn main() {
+    let sem = Arc::new(PrioritySemaphore::new(1));
+
+    let high = sem.clone();
+    let high_task = tokio::spawn(async move {
+        let _permit = high.acquire(10).await.unwrap();
+        println!("high priority task acquired permit");
+    });
+
+    let low = sem.clone();
+    let low_task = tokio::spawn(async move {
+        let _permit = low.acquire(1).await.unwrap();
+        println!("low priority task acquired permit");
+    });
+
+    high_task.await.unwrap();
+    low_task.await.unwrap();
+}

--- a/examples/try_acquire.rs
+++ b/examples/try_acquire.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+use priority_semaphore::{PrioritySemaphore, TryAcquireError};
+
+fn main() {
+    let sem = Arc::new(PrioritySemaphore::new(2));
+
+    match sem.try_acquire(0) {
+        Ok(_permit) => println!("first permit immediate"),
+        Err(_) => println!("failed to acquire first permit"),
+    }
+
+    match sem.try_acquire(0) {
+        Ok(_permit) => println!("second permit immediate"),
+        Err(_) => println!("failed to acquire second permit"),
+    }
+
+    match sem.try_acquire(0) {
+        Ok(_) => println!("unexpected third permit"),
+        Err(TryAcquireError::NoPermits) => println!("no permits left"),
+        Err(TryAcquireError::Closed) => unreachable!(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,32 @@
 
 //! Runtime-agnostic priority semaphore.
 //!
+//! This crate provides [`PrioritySemaphore`], an asynchronous semaphore where
+//! waiters supply a signed priority. Higher priorities are awakened before
+//! lower ones. The implementation is runtime agnostic and works with either
+//! **Tokio** or **async-std** when the corresponding feature is enabled.
+//!
+//! ```rust
+//! use std::sync::Arc;
+//! use priority_semaphore::PrioritySemaphore;
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! let sem = Arc::new(PrioritySemaphore::new(1));
+//!
+//! let hi = sem.clone();
+//! tokio::spawn(async move {
+//!     let _permit = hi.acquire(10).await.unwrap();
+//!     println!("high priority acquired");
+//! });
+//!
+//! let lo = sem.clone();
+//! tokio::spawn(async move {
+//!     let _permit = lo.acquire(1).await.unwrap();
+//!     println!("low priority acquired");
+//! });
+//! # }
+//! ```
 
 extern crate alloc;
 #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary
- add runnable examples
- expand crate docs with an introductory example
- rewrite the English README and provide a Japanese translation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685a627d972c832c954b08926ae5a453